### PR TITLE
Add pricing comparison slider and locale rewrite support

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,8 @@
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteBase /
+
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule ^ index.php [L]
+</IfModule>

--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -914,16 +914,117 @@ html.no-js .nav-toggle {
   gap: 28px;
 }
 
-.comparison-grid {
-  display: grid;
+.comparison-slider {
+  position: relative;
+}
+
+.comparison-track {
+  display: flex;
   gap: 20px;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  padding: 4px 16px;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.comparison-track::-webkit-scrollbar {
+  display: none;
+}
+
+.comparison-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 22px;
+  font-weight: 600;
+  line-height: 1;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
+  transition: background 0.2s ease, color 0.2s ease, opacity 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.comparison-nav:hover,
+.comparison-nav:focus-visible {
+  background: var(--color-primary);
+  color: #fff;
+  box-shadow: 0 18px 44px rgba(37, 99, 235, 0.28);
+}
+
+.comparison-nav:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.comparison-nav:disabled {
+  opacity: 0.35;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.comparison-slider:not(.is-scrollable) .comparison-nav {
+  opacity: 0.35;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.comparison-nav span[aria-hidden='true'] {
+  display: block;
+  transform: translateY(-1px);
+}
+
+.comparison-nav-prev {
+  left: clamp(12px, 4vw, 32px);
+}
+
+.comparison-nav-next {
+  right: clamp(12px, 4vw, 32px);
+}
+
+@media (max-width: 599px) {
+  .comparison-track {
+    padding: 4px 12px;
+  }
+
+  .comparison-nav {
+    width: 36px;
+    height: 36px;
+    font-size: 20px;
+  }
 }
 
 .comparison-card {
   display: grid;
   gap: 18px;
   align-content: start;
+}
+
+.comparison-track .comparison-card {
+  flex: 0 0 calc(100% - 32px);
+  min-width: min(100%, 320px);
+  scroll-snap-align: start;
+}
+
+@media (min-width: 640px) {
+  .comparison-track .comparison-card {
+    flex-basis: calc((100% - 20px) / 2);
+  }
+}
+
+@media (min-width: 1080px) {
+  .comparison-track .comparison-card {
+    flex-basis: calc((100% - 40px) / 3);
+  }
 }
 
 .comparison-card-title {
@@ -1590,15 +1691,6 @@ input[type='range'] {
   gap: 20px;
 }
 
-.outcome-card::before {
-  content: '';
-  position: absolute;
-  inset: 18px 18px auto;
-  height: 2px;
-  border-radius: 999px;
-  background: linear-gradient(90deg, rgba(37, 99, 235, 0.45), transparent);
-}
-
 .outcome-value {
   font-size: clamp(28px, 4vw, 42px);
   font-weight: 800;
@@ -1607,7 +1699,7 @@ input[type='range'] {
 }
 
 .outcomes-footnote {
-  margin-top: 18px;
+  margin-top: 32px;
   max-width: 520px;
 }
 

--- a/translations/en.php
+++ b/translations/en.php
@@ -261,6 +261,8 @@ return [
             'cons_label' => 'Cons',
             'nerp_tokens_suffix' => 'tokens / month',
             'team_caption' => 'for {count} people',
+            'nav_prev' => 'Previous',
+            'nav_next' => 'Next',
             'systems' => [
                 [
                     'id' => 'google-sheets',
@@ -291,8 +293,8 @@ return [
                 [
                     'id' => '1c',
                     'name' => '1C',
-                    'price_per_user' => 35,
-                    'price_period' => 'per user / month (cloud)',
+                    'price_per_user' => 20,
+                    'price_period' => 'per user / month (1C:CRM Cloud)',
                     'nerp' => [
                         'pros' => [
                             'Handles complex workflows without custom code.',
@@ -317,8 +319,8 @@ return [
                 [
                     'id' => 'amocrm',
                     'name' => 'amoCRM',
-                    'price_per_user' => 25,
-                    'price_period' => 'per user / month (Advanced)',
+                    'price_per_user' => 28,
+                    'price_period' => 'per user / month (Pro, monthly billing)',
                     'nerp' => [
                         'pros' => [
                             'Covers finance, warehouse, and logistics beyond sales.',
@@ -343,8 +345,8 @@ return [
                 [
                     'id' => 'bitrix24',
                     'name' => 'Bitrix24',
-                    'price_per_user' => 24,
-                    'price_period' => 'per user / month (Teams plan)',
+                    'price_per_user' => 22,
+                    'price_period' => 'per user / month (Team, monthly billing)',
                     'nerp' => [
                         'pros' => [
                             'Designed for cross-team operational workflows.',

--- a/translations/ru.php
+++ b/translations/ru.php
@@ -251,6 +251,8 @@ return [
             'cons_label' => 'Минусы',
             'nerp_tokens_suffix' => 'токенов в месяц',
             'team_caption' => 'за {count} человек',
+            'nav_prev' => 'Назад',
+            'nav_next' => 'Вперёд',
             'systems' => [
                 [
                     'id' => 'google-sheets',
@@ -282,7 +284,7 @@ return [
                     'id' => '1c',
                     'name' => '1C',
                     'price_per_user' => 1800,
-                    'price_period' => 'в месяц за пользователя (SaaS)',
+                    'price_period' => 'в месяц за пользователя (1С:CRM.Облако)',
                     'nerp' => [
                         'pros' => [
                             'Сложные процессы без долгой кастомной разработки.',
@@ -307,8 +309,8 @@ return [
                 [
                     'id' => 'amocrm',
                     'name' => 'amoCRM',
-                    'price_per_user' => 2400,
-                    'price_period' => 'в месяц за пользователя (Advanced)',
+                    'price_per_user' => 2490,
+                    'price_period' => 'в месяц за пользователя (Профи, помесячно)',
                     'nerp' => [
                         'pros' => [
                             'Учитываем процессы за пределами отдела продаж.',
@@ -334,7 +336,7 @@ return [
                     'id' => 'bitrix24',
                     'name' => 'Bitrix24',
                     'price_per_user' => 1990,
-                    'price_period' => 'в месяц за пользователя (Команда)',
+                    'price_period' => 'в месяц за пользователя (Команда, помесячно)',
                     'nerp' => [
                         'pros' => [
                             'Фокус на межфункциональные операционные процессы.',

--- a/views/home.php
+++ b/views/home.php
@@ -146,6 +146,8 @@ $pricingComparison = [
     'cons_label' => $isRussianLocale ? 'Минусы' : 'Cons',
     'nerp_tokens_suffix' => $isRussianLocale ? 'токенов в месяц' : 'tokens / month',
     'team_caption' => $isRussianLocale ? 'за {count} человек' : 'for {count} people',
+    'nav_prev' => $isRussianLocale ? 'Назад' : 'Previous',
+    'nav_next' => $isRussianLocale ? 'Вперёд' : 'Next',
 ];
 $pricingComparisonSystems = [];
 if (is_array($pricingComparisonConfig)) {
@@ -156,6 +158,8 @@ if (is_array($pricingComparisonConfig)) {
     $pricingComparison['cons_label'] = (string) ($pricingComparisonConfig['cons_label'] ?? $pricingComparison['cons_label']);
     $pricingComparison['nerp_tokens_suffix'] = (string) ($pricingComparisonConfig['nerp_tokens_suffix'] ?? $pricingComparison['nerp_tokens_suffix']);
     $pricingComparison['team_caption'] = (string) ($pricingComparisonConfig['team_caption'] ?? $pricingComparison['team_caption']);
+    $pricingComparison['nav_prev'] = (string) ($pricingComparisonConfig['nav_prev'] ?? $pricingComparison['nav_prev']);
+    $pricingComparison['nav_next'] = (string) ($pricingComparisonConfig['nav_next'] ?? $pricingComparison['nav_next']);
 
     $normalizePoints = static function ($points): array {
         $result = [];
@@ -254,90 +258,6 @@ if (is_array($pricingComparisonConfig)) {
         <?php endforeach; ?>
     </div>
 </section>
-
-<?php if ($pricingComparisonSystems !== []): ?>
-    <section class="container pricing-comparison" id="pricing-comparison">
-        <?php if (!empty($pricingComparison['title'])): ?>
-            <h2 class="h2"><?= e($pricingComparison['title']); ?></h2>
-        <?php endif; ?>
-        <?php if (!empty($pricingComparison['subtitle'])): ?>
-            <p class="muted"><?= e($pricingComparison['subtitle']); ?></p>
-        <?php endif; ?>
-        <div class="comparison-grid">
-            <?php foreach ($pricingComparisonSystems as $system): ?>
-                <?php
-                $pricePerUserAttr = number_format((float) $system['price_per_user'], 4, '.', '');
-                $priceFlatAttr = number_format((float) $system['price_flat'], 4, '.', '');
-                $priceMinAttr = number_format((float) $system['price_min'], 4, '.', '');
-                $teamTemplate = (string) ($pricingComparison['team_caption'] ?? '');
-                $teamDefault = $teamTemplate !== '' ? str_replace('{count}', '—', $teamTemplate) : '';
-                ?>
-                <article class="card comparison-card" data-comparison-system data-price-per-user="<?= e($pricePerUserAttr); ?>" data-price-flat="<?= e($priceFlatAttr); ?>" data-price-min="<?= e($priceMinAttr); ?>" id="comparison-<?= e($system['id']); ?>">
-                    <h3 class="comparison-card-title"><?= e($system['name']); ?></h3>
-                    <div class="comparison-columns">
-                        <div class="comparison-column is-nerp">
-                            <div class="comparison-label"><?= e($pricingComparison['nerp_label']); ?></div>
-                            <div class="comparison-value" data-comparison-nerp-fiat>—</div>
-                            <div class="comparison-subvalue" data-comparison-nerp-tokens data-token-suffix="<?= e($pricingComparison['nerp_tokens_suffix']); ?>">—</div>
-                            <div class="comparison-points">
-                                <?php if ($system['nerp_pros'] !== []): ?>
-                                    <div class="comparison-point-group positive">
-                                        <div class="comparison-point-title"><?= e($pricingComparison['pros_label']); ?></div>
-                                        <ul class="comparison-point-list">
-                                            <?php foreach ($system['nerp_pros'] as $point): ?>
-                                                <li><?= e($point); ?></li>
-                                            <?php endforeach; ?>
-                                        </ul>
-                                    </div>
-                                <?php endif; ?>
-                                <?php if ($system['nerp_cons'] !== []): ?>
-                                    <div class="comparison-point-group negative">
-                                        <div class="comparison-point-title"><?= e($pricingComparison['cons_label']); ?></div>
-                                        <ul class="comparison-point-list">
-                                            <?php foreach ($system['nerp_cons'] as $point): ?>
-                                                <li><?= e($point); ?></li>
-                                            <?php endforeach; ?>
-                                        </ul>
-                                    </div>
-                                <?php endif; ?>
-                            </div>
-                        </div>
-                        <div class="comparison-column">
-                            <div class="comparison-label"><?= e($system['name']); ?></div>
-                            <div class="comparison-value" data-comparison-system-price>—</div>
-                            <?php if (!empty($system['price_period'])): ?>
-                                <div class="comparison-subvalue"><?= e($system['price_period']); ?></div>
-                            <?php endif; ?>
-                            <div class="comparison-points">
-                                <?php if ($system['system_pros'] !== []): ?>
-                                    <div class="comparison-point-group positive">
-                                        <div class="comparison-point-title"><?= e($pricingComparison['pros_label']); ?></div>
-                                        <ul class="comparison-point-list">
-                                            <?php foreach ($system['system_pros'] as $point): ?>
-                                                <li><?= e($point); ?></li>
-                                            <?php endforeach; ?>
-                                        </ul>
-                                    </div>
-                                <?php endif; ?>
-                                <?php if ($system['system_cons'] !== []): ?>
-                                    <div class="comparison-point-group negative">
-                                        <div class="comparison-point-title"><?= e($pricingComparison['cons_label']); ?></div>
-                                        <ul class="comparison-point-list">
-                                            <?php foreach ($system['system_cons'] as $point): ?>
-                                                <li><?= e($point); ?></li>
-                                            <?php endforeach; ?>
-                                        </ul>
-                                    </div>
-                                <?php endif; ?>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="comparison-team-note" data-comparison-team data-template="<?= e($pricingComparison['team_caption']); ?>"><?= e($teamDefault); ?></div>
-                </article>
-            <?php endforeach; ?>
-        </div>
-    </section>
-<?php endif; ?>
 
 <div class="divider" role="presentation"></div>
 
@@ -743,6 +663,118 @@ if (is_array($pricingComparisonConfig)) {
         </div>
     </div>
 </section>
+
+<?php if ($pricingComparisonSystems !== []): ?>
+    <section class="container pricing-comparison" id="pricing-comparison">
+        <?php if (!empty($pricingComparison['title'])): ?>
+            <h2 class="h2"><?= e($pricingComparison['title']); ?></h2>
+        <?php endif; ?>
+        <?php if (!empty($pricingComparison['subtitle'])): ?>
+            <p class="muted"><?= e($pricingComparison['subtitle']); ?></p>
+        <?php endif; ?>
+        <div class="comparison-slider" data-comparison-slider>
+            <button
+                class="comparison-nav comparison-nav-prev"
+                type="button"
+                data-slider-prev
+                aria-label="<?= e($pricingComparison['nav_prev']); ?>"
+            >
+                <span aria-hidden="true">‹</span>
+                <span class="sr-only"><?= e($pricingComparison['nav_prev']); ?></span>
+            </button>
+            <div class="comparison-track" data-comparison-track>
+                <?php foreach ($pricingComparisonSystems as $system): ?>
+                    <?php
+                    $pricePerUserAttr = number_format((float) $system['price_per_user'], 4, '.', '');
+                    $priceFlatAttr = number_format((float) $system['price_flat'], 4, '.', '');
+                    $priceMinAttr = number_format((float) $system['price_min'], 4, '.', '');
+                    $teamTemplate = (string) ($pricingComparison['team_caption'] ?? '');
+                    $teamDefault = $teamTemplate !== '' ? str_replace('{count}', '—', $teamTemplate) : '';
+                    ?>
+                    <article
+                        class="card comparison-card"
+                        data-comparison-system
+                        data-comparison-slide
+                        data-price-per-user="<?= e($pricePerUserAttr); ?>"
+                        data-price-flat="<?= e($priceFlatAttr); ?>"
+                        data-price-min="<?= e($priceMinAttr); ?>"
+                        id="comparison-<?= e($system['id']); ?>"
+                    >
+                        <h3 class="comparison-card-title"><?= e($system['name']); ?></h3>
+                        <div class="comparison-columns">
+                            <div class="comparison-column is-nerp">
+                                <div class="comparison-label"><?= e($pricingComparison['nerp_label']); ?></div>
+                                <div class="comparison-value" data-comparison-nerp-fiat>—</div>
+                                <div class="comparison-subvalue" data-comparison-nerp-tokens data-token-suffix="<?= e($pricingComparison['nerp_tokens_suffix']); ?>">—</div>
+                                <div class="comparison-points">
+                                    <?php if ($system['nerp_pros'] !== []): ?>
+                                        <div class="comparison-point-group positive">
+                                            <div class="comparison-point-title"><?= e($pricingComparison['pros_label']); ?></div>
+                                            <ul class="comparison-point-list">
+                                                <?php foreach ($system['nerp_pros'] as $point): ?>
+                                                    <li><?= e($point); ?></li>
+                                                <?php endforeach; ?>
+                                            </ul>
+                                        </div>
+                                    <?php endif; ?>
+                                    <?php if ($system['nerp_cons'] !== []): ?>
+                                        <div class="comparison-point-group negative">
+                                            <div class="comparison-point-title"><?= e($pricingComparison['cons_label']); ?></div>
+                                            <ul class="comparison-point-list">
+                                                <?php foreach ($system['nerp_cons'] as $point): ?>
+                                                    <li><?= e($point); ?></li>
+                                                <?php endforeach; ?>
+                                            </ul>
+                                        </div>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+                            <div class="comparison-column">
+                                <div class="comparison-label"><?= e($system['name']); ?></div>
+                                <div class="comparison-value" data-comparison-system-price>—</div>
+                                <?php if (!empty($system['price_period'])): ?>
+                                    <div class="comparison-subvalue"><?= e($system['price_period']); ?></div>
+                                <?php endif; ?>
+                                <div class="comparison-points">
+                                    <?php if ($system['system_pros'] !== []): ?>
+                                        <div class="comparison-point-group positive">
+                                            <div class="comparison-point-title"><?= e($pricingComparison['pros_label']); ?></div>
+                                            <ul class="comparison-point-list">
+                                                <?php foreach ($system['system_pros'] as $point): ?>
+                                                    <li><?= e($point); ?></li>
+                                                <?php endforeach; ?>
+                                            </ul>
+                                        </div>
+                                    <?php endif; ?>
+                                    <?php if ($system['system_cons'] !== []): ?>
+                                        <div class="comparison-point-group negative">
+                                            <div class="comparison-point-title"><?= e($pricingComparison['cons_label']); ?></div>
+                                            <ul class="comparison-point-list">
+                                                <?php foreach ($system['system_cons'] as $point): ?>
+                                                    <li><?= e($point); ?></li>
+                                                <?php endforeach; ?>
+                                            </ul>
+                                        </div>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="comparison-team-note" data-comparison-team data-template="<?= e($pricingComparison['team_caption']); ?>"><?= e($teamDefault); ?></div>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+            <button
+                class="comparison-nav comparison-nav-next"
+                type="button"
+                data-slider-next
+                aria-label="<?= e($pricingComparison['nav_next']); ?>"
+            >
+                <span aria-hidden="true">›</span>
+                <span class="sr-only"><?= e($pricingComparison['nav_next']); ?></span>
+            </button>
+        </div>
+    </section>
+<?php endif; ?>
 
 <div class="divider" role="presentation"></div>
 


### PR DESCRIPTION
## Summary
- add Apache rewrite rules so locale-prefixed URLs route through index.php
- move the ERP/CRM pricing comparison under the pricing calculator and turn it into a horizontal slider with navigation controls
- refresh competitor pricing data, translations, and spacing while removing the outdated outcome card accent

## Testing
- php -l views/home.php

------
https://chatgpt.com/codex/tasks/task_e_68e2d701d00c8325a5ff27f314e422bb