### PR TITLE
Add rewrite routing and slider for pricing comparison

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,9 @@
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+
+    RewriteCond %{REQUEST_FILENAME} -f [OR]
+    RewriteCond %{REQUEST_FILENAME} -d
+    RewriteRule ^ - [L]
+
+    RewriteRule ^ index.php [QSA,L]
+</IfModule>

--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -914,16 +914,34 @@ html.no-js .nav-toggle {
   gap: 28px;
 }
 
-.comparison-grid {
+.comparison-slider {
+  position: relative;
   display: grid;
   gap: 20px;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.comparison-grid {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(280px, min(360px, 85vw));
+  gap: 20px;
+  overflow-x: auto;
+  padding: 4px 0 12px;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.comparison-grid::-webkit-scrollbar {
+  display: none;
 }
 
 .comparison-card {
   display: grid;
   gap: 18px;
   align-content: start;
+  min-width: 280px;
+  scroll-snap-align: start;
 }
 
 .comparison-card-title {
@@ -1005,6 +1023,69 @@ html.no-js .nav-toggle {
   gap: 6px;
   font-size: 14px;
   line-height: 1.5;
+}
+
+.comparison-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 24px;
+  line-height: 1;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.comparison-slider.has-overflow .comparison-nav {
+  display: inline-flex;
+}
+
+.comparison-nav[data-comparison-nav='prev'] {
+  left: 12px;
+}
+
+.comparison-nav[data-comparison-nav='next'] {
+  right: 12px;
+}
+
+.comparison-nav:hover,
+.comparison-nav:focus-visible {
+  transform: translateY(-50%) scale(1.05);
+  box-shadow: var(--shadow-lg);
+}
+
+.comparison-nav:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+}
+
+.comparison-nav[disabled] {
+  opacity: 0.35;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+@media (min-width: 1100px) {
+  .comparison-grid {
+    grid-auto-columns: minmax(320px, 1fr);
+  }
+
+  .comparison-nav[data-comparison-nav='prev'] {
+    left: -20px;
+  }
+
+  .comparison-nav[data-comparison-nav='next'] {
+    right: -20px;
+  }
 }
 
 .pricing-notice {
@@ -1590,15 +1671,6 @@ input[type='range'] {
   gap: 20px;
 }
 
-.outcome-card::before {
-  content: '';
-  position: absolute;
-  inset: 18px 18px auto;
-  height: 2px;
-  border-radius: 999px;
-  background: linear-gradient(90deg, rgba(37, 99, 235, 0.45), transparent);
-}
-
 .outcome-value {
   font-size: clamp(28px, 4vw, 42px);
   font-weight: 800;
@@ -1607,7 +1679,7 @@ input[type='range'] {
 }
 
 .outcomes-footnote {
-  margin-top: 18px;
+  margin-top: 28px;
   max-width: 520px;
 }
 

--- a/translations/en.php
+++ b/translations/en.php
@@ -261,12 +261,14 @@ return [
             'cons_label' => 'Cons',
             'nerp_tokens_suffix' => 'tokens / month',
             'team_caption' => 'for {count} people',
+            'nav_prev' => 'Scroll back',
+            'nav_next' => 'Scroll forward',
             'systems' => [
                 [
                     'id' => 'google-sheets',
                     'name' => 'Google Sheets',
                     'price_per_user' => 12,
-                    'price_period' => 'per user / month (Business Standard)',
+                    'price_period' => 'per user / month (Business Standard, billed monthly)',
                     'nerp' => [
                         'pros' => [
                             'Usage-based spend scales only with real activity.',
@@ -291,8 +293,8 @@ return [
                 [
                     'id' => '1c',
                     'name' => '1C',
-                    'price_per_user' => 35,
-                    'price_period' => 'per user / month (cloud)',
+                    'price_per_user' => 32,
+                    'price_period' => 'per user / month (1C:CRM PRO SaaS, billed monthly)',
                     'nerp' => [
                         'pros' => [
                             'Handles complex workflows without custom code.',
@@ -317,8 +319,9 @@ return [
                 [
                     'id' => 'amocrm',
                     'name' => 'amoCRM',
-                    'price_per_user' => 25,
-                    'price_period' => 'per user / month (Advanced)',
+                    'price_per_user' => 28,
+                    'price_min' => 138,
+                    'price_period' => 'per user / month (Advanced plan, ₽2,490 with 5-seat bundle)',
                     'nerp' => [
                         'pros' => [
                             'Covers finance, warehouse, and logistics beyond sales.',
@@ -343,8 +346,9 @@ return [
                 [
                     'id' => 'bitrix24',
                     'name' => 'Bitrix24',
-                    'price_per_user' => 24,
-                    'price_period' => 'per user / month (Teams plan)',
+                    'price_per_user' => 33,
+                    'price_min' => 165,
+                    'price_period' => 'per user / month (Team plan, ₽2,990 with 5-seat bundle)',
                     'nerp' => [
                         'pros' => [
                             'Designed for cross-team operational workflows.',

--- a/translations/ru.php
+++ b/translations/ru.php
@@ -251,12 +251,14 @@ return [
             'cons_label' => 'Минусы',
             'nerp_tokens_suffix' => 'токенов в месяц',
             'team_caption' => 'за {count} человек',
+            'nav_prev' => 'Назад',
+            'nav_next' => 'Вперёд',
             'systems' => [
                 [
                     'id' => 'google-sheets',
                     'name' => 'Google Таблицы',
                     'price_per_user' => 1100,
-                    'price_period' => 'в месяц за пользователя (Business Standard)',
+                    'price_period' => 'в месяц за пользователя (Business Standard, помесячно)',
                     'nerp' => [
                         'pros' => [
                             'Платите только за действия — без простаивающих лицензий.',
@@ -281,8 +283,8 @@ return [
                 [
                     'id' => '1c',
                     'name' => '1C',
-                    'price_per_user' => 1800,
-                    'price_period' => 'в месяц за пользователя (SaaS)',
+                    'price_per_user' => 2100,
+                    'price_period' => 'в месяц за пользователя (SaaS «1С:CRM ПРО», помесячно)',
                     'nerp' => [
                         'pros' => [
                             'Сложные процессы без долгой кастомной разработки.',
@@ -307,8 +309,9 @@ return [
                 [
                     'id' => 'amocrm',
                     'name' => 'amoCRM',
-                    'price_per_user' => 2400,
-                    'price_period' => 'в месяц за пользователя (Advanced)',
+                    'price_per_user' => 2490,
+                    'price_min' => 12450,
+                    'price_period' => 'в месяц за пользователя (тариф Advanced, пакет 5 пользователей — 12 450 ₽, помесячно)',
                     'nerp' => [
                         'pros' => [
                             'Учитываем процессы за пределами отдела продаж.',
@@ -333,8 +336,9 @@ return [
                 [
                     'id' => 'bitrix24',
                     'name' => 'Bitrix24',
-                    'price_per_user' => 1990,
-                    'price_period' => 'в месяц за пользователя (Команда)',
+                    'price_per_user' => 2990,
+                    'price_min' => 14950,
+                    'price_period' => 'в месяц за пользователя (тариф «Команда», пакет 5 пользователей — 14 950 ₽, помесячно)',
                     'nerp' => [
                         'pros' => [
                             'Фокус на межфункциональные операционные процессы.',

--- a/views/home.php
+++ b/views/home.php
@@ -255,90 +255,6 @@ if (is_array($pricingComparisonConfig)) {
     </div>
 </section>
 
-<?php if ($pricingComparisonSystems !== []): ?>
-    <section class="container pricing-comparison" id="pricing-comparison">
-        <?php if (!empty($pricingComparison['title'])): ?>
-            <h2 class="h2"><?= e($pricingComparison['title']); ?></h2>
-        <?php endif; ?>
-        <?php if (!empty($pricingComparison['subtitle'])): ?>
-            <p class="muted"><?= e($pricingComparison['subtitle']); ?></p>
-        <?php endif; ?>
-        <div class="comparison-grid">
-            <?php foreach ($pricingComparisonSystems as $system): ?>
-                <?php
-                $pricePerUserAttr = number_format((float) $system['price_per_user'], 4, '.', '');
-                $priceFlatAttr = number_format((float) $system['price_flat'], 4, '.', '');
-                $priceMinAttr = number_format((float) $system['price_min'], 4, '.', '');
-                $teamTemplate = (string) ($pricingComparison['team_caption'] ?? '');
-                $teamDefault = $teamTemplate !== '' ? str_replace('{count}', '—', $teamTemplate) : '';
-                ?>
-                <article class="card comparison-card" data-comparison-system data-price-per-user="<?= e($pricePerUserAttr); ?>" data-price-flat="<?= e($priceFlatAttr); ?>" data-price-min="<?= e($priceMinAttr); ?>" id="comparison-<?= e($system['id']); ?>">
-                    <h3 class="comparison-card-title"><?= e($system['name']); ?></h3>
-                    <div class="comparison-columns">
-                        <div class="comparison-column is-nerp">
-                            <div class="comparison-label"><?= e($pricingComparison['nerp_label']); ?></div>
-                            <div class="comparison-value" data-comparison-nerp-fiat>—</div>
-                            <div class="comparison-subvalue" data-comparison-nerp-tokens data-token-suffix="<?= e($pricingComparison['nerp_tokens_suffix']); ?>">—</div>
-                            <div class="comparison-points">
-                                <?php if ($system['nerp_pros'] !== []): ?>
-                                    <div class="comparison-point-group positive">
-                                        <div class="comparison-point-title"><?= e($pricingComparison['pros_label']); ?></div>
-                                        <ul class="comparison-point-list">
-                                            <?php foreach ($system['nerp_pros'] as $point): ?>
-                                                <li><?= e($point); ?></li>
-                                            <?php endforeach; ?>
-                                        </ul>
-                                    </div>
-                                <?php endif; ?>
-                                <?php if ($system['nerp_cons'] !== []): ?>
-                                    <div class="comparison-point-group negative">
-                                        <div class="comparison-point-title"><?= e($pricingComparison['cons_label']); ?></div>
-                                        <ul class="comparison-point-list">
-                                            <?php foreach ($system['nerp_cons'] as $point): ?>
-                                                <li><?= e($point); ?></li>
-                                            <?php endforeach; ?>
-                                        </ul>
-                                    </div>
-                                <?php endif; ?>
-                            </div>
-                        </div>
-                        <div class="comparison-column">
-                            <div class="comparison-label"><?= e($system['name']); ?></div>
-                            <div class="comparison-value" data-comparison-system-price>—</div>
-                            <?php if (!empty($system['price_period'])): ?>
-                                <div class="comparison-subvalue"><?= e($system['price_period']); ?></div>
-                            <?php endif; ?>
-                            <div class="comparison-points">
-                                <?php if ($system['system_pros'] !== []): ?>
-                                    <div class="comparison-point-group positive">
-                                        <div class="comparison-point-title"><?= e($pricingComparison['pros_label']); ?></div>
-                                        <ul class="comparison-point-list">
-                                            <?php foreach ($system['system_pros'] as $point): ?>
-                                                <li><?= e($point); ?></li>
-                                            <?php endforeach; ?>
-                                        </ul>
-                                    </div>
-                                <?php endif; ?>
-                                <?php if ($system['system_cons'] !== []): ?>
-                                    <div class="comparison-point-group negative">
-                                        <div class="comparison-point-title"><?= e($pricingComparison['cons_label']); ?></div>
-                                        <ul class="comparison-point-list">
-                                            <?php foreach ($system['system_cons'] as $point): ?>
-                                                <li><?= e($point); ?></li>
-                                            <?php endforeach; ?>
-                                        </ul>
-                                    </div>
-                                <?php endif; ?>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="comparison-team-note" data-comparison-team data-template="<?= e($pricingComparison['team_caption']); ?>"><?= e($teamDefault); ?></div>
-                </article>
-            <?php endforeach; ?>
-        </div>
-    </section>
-<?php endif; ?>
-
 <div class="divider" role="presentation"></div>
 
 <section id="for" class="container audience-section">
@@ -743,6 +659,109 @@ if (is_array($pricingComparisonConfig)) {
         </div>
     </div>
 </section>
+
+<?php if ($pricingComparisonSystems !== []): ?>
+    <section class="container pricing-comparison" id="pricing-comparison">
+        <?php if (!empty($pricingComparison['title'])): ?>
+            <h2 class="h2"><?= e($pricingComparison['title']); ?></h2>
+        <?php endif; ?>
+        <?php if (!empty($pricingComparison['subtitle'])): ?>
+            <p class="muted"><?= e($pricingComparison['subtitle']); ?></p>
+        <?php endif; ?>
+        <div class="comparison-slider" data-comparison-slider>
+            <button
+                type="button"
+                class="comparison-nav"
+                data-comparison-nav="prev"
+                aria-label="<?= e((string) ($t->get('pricing.comparison.nav_prev') ?? '')); ?>"
+                disabled
+            >
+                ‹
+            </button>
+            <div class="comparison-grid" data-comparison-track>
+                <?php foreach ($pricingComparisonSystems as $system): ?>
+                    <?php
+                    $pricePerUserAttr = number_format((float) $system['price_per_user'], 4, '.', '');
+                    $priceFlatAttr = number_format((float) $system['price_flat'], 4, '.', '');
+                    $priceMinAttr = number_format((float) $system['price_min'], 4, '.', '');
+                    $teamTemplate = (string) ($pricingComparison['team_caption'] ?? '');
+                    $teamDefault = $teamTemplate !== '' ? str_replace('{count}', '—', $teamTemplate) : '';
+                    ?>
+                    <article class="card comparison-card" data-comparison-system data-price-per-user="<?= e($pricePerUserAttr); ?>" data-price-flat="<?= e($priceFlatAttr); ?>" data-price-min="<?= e($priceMinAttr); ?>" id="comparison-<?= e($system['id']); ?>">
+                        <h3 class="comparison-card-title"><?= e($system['name']); ?></h3>
+                        <div class="comparison-columns">
+                            <div class="comparison-column is-nerp">
+                                <div class="comparison-label"><?= e($pricingComparison['nerp_label']); ?></div>
+                                <div class="comparison-value" data-comparison-nerp-fiat>—</div>
+                                <div class="comparison-subvalue" data-comparison-nerp-tokens data-token-suffix="<?= e($pricingComparison['nerp_tokens_suffix']); ?>">—</div>
+                                <div class="comparison-points">
+                                    <?php if ($system['nerp_pros'] !== []): ?>
+                                        <div class="comparison-point-group positive">
+                                            <div class="comparison-point-title"><?= e($pricingComparison['pros_label']); ?></div>
+                                            <ul class="comparison-point-list">
+                                                <?php foreach ($system['nerp_pros'] as $point): ?>
+                                                    <li><?= e($point); ?></li>
+                                                <?php endforeach; ?>
+                                            </ul>
+                                        </div>
+                                    <?php endif; ?>
+                                    <?php if ($system['nerp_cons'] !== []): ?>
+                                        <div class="comparison-point-group negative">
+                                            <div class="comparison-point-title"><?= e($pricingComparison['cons_label']); ?></div>
+                                            <ul class="comparison-point-list">
+                                                <?php foreach ($system['nerp_cons'] as $point): ?>
+                                                    <li><?= e($point); ?></li>
+                                                <?php endforeach; ?>
+                                            </ul>
+                                        </div>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+                            <div class="comparison-column">
+                                <div class="comparison-label"><?= e($system['name']); ?></div>
+                                <div class="comparison-value" data-comparison-system-price>—</div>
+                                <?php if (!empty($system['price_period'])): ?>
+                                    <div class="comparison-subvalue"><?= e($system['price_period']); ?></div>
+                                <?php endif; ?>
+                                <div class="comparison-points">
+                                    <?php if ($system['system_pros'] !== []): ?>
+                                        <div class="comparison-point-group positive">
+                                            <div class="comparison-point-title"><?= e($pricingComparison['pros_label']); ?></div>
+                                            <ul class="comparison-point-list">
+                                                <?php foreach ($system['system_pros'] as $point): ?>
+                                                    <li><?= e($point); ?></li>
+                                                <?php endforeach; ?>
+                                            </ul>
+                                        </div>
+                                    <?php endif; ?>
+                                    <?php if ($system['system_cons'] !== []): ?>
+                                        <div class="comparison-point-group negative">
+                                            <div class="comparison-point-title"><?= e($pricingComparison['cons_label']); ?></div>
+                                            <ul class="comparison-point-list">
+                                                <?php foreach ($system['system_cons'] as $point): ?>
+                                                    <li><?= e($point); ?></li>
+                                                <?php endforeach; ?>
+                                            </ul>
+                                        </div>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="comparison-team-note" data-comparison-team data-template="<?= e($pricingComparison['team_caption']); ?>"><?= e($teamDefault); ?></div>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+            <button
+                type="button"
+                class="comparison-nav"
+                data-comparison-nav="next"
+                aria-label="<?= e((string) ($t->get('pricing.comparison.nav_next') ?? '')); ?>"
+            >
+                ›
+            </button>
+        </div>
+    </section>
+<?php endif; ?>
 
 <div class="divider" role="presentation"></div>
 


### PR DESCRIPTION
## Summary
- add Apache rewrite rules so localized URLs such as `/en/` route correctly
- move the pricing comparison block below the calculator and render it as a horizontal slider with accessible controls
- refresh competitor pricing data and related styles, including updated translations and spacing tweaks

## Testing
- php -l views/home.php
- php -l translations/en.php
- php -l translations/ru.php

------
https://chatgpt.com/codex/tasks/task_e_68e2d701d00c8325a5ff27f314e422bb