### PR TITLE
Refine hero illustration and enablement timeline styling

### DIFF
--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -672,7 +672,6 @@ html.no-js .nav-toggle {
   border-radius: 32px;
   border: 1px solid var(--color-border);
   box-shadow: var(--shadow-lg);
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.35), rgba(14, 165, 233, 0.12));
 }
 
 :root[data-theme='dark'] .illustration img {
@@ -1723,6 +1722,10 @@ input[type='range'] {
   max-width: 520px;
 }
 
+.outcomes-section > .outcomes-footnote {
+  margin-top: 40px;
+}
+
 .enablement-header {
   display: grid;
   gap: 12px;
@@ -1731,23 +1734,78 @@ input[type='range'] {
 
 .enablement-timeline {
   display: grid;
-  gap: 16px;
-  margin-top: 28px;
+  gap: 20px;
+  margin-top: 32px;
+  padding-left: 12px;
+  position: relative;
 }
 
 .enablement-stage {
   position: relative;
-  overflow: hidden;
-  gap: 14px;
+  display: grid;
+  grid-template-columns: 48px 1fr;
+  gap: 18px;
+  align-items: start;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+.enablement-stage::after {
+  content: '';
+  position: absolute;
+  left: 36px;
+  top: 64px;
+  bottom: -24px;
+  width: 2px;
+  background: var(--color-border);
+}
+
+.enablement-stage:last-child::after {
+  content: none;
 }
 
 .stage-index {
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
   font-weight: 700;
   font-size: 14px;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--color-primary);
   font-variant-numeric: tabular-nums;
+  box-shadow: var(--shadow-sm);
+  justify-self: center;
+  align-self: start;
+}
+
+.enablement-stage > div:last-child {
+  padding: 20px 24px;
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-strong);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  display: grid;
+  gap: 8px;
+}
+
+:root[data-theme='dark'] .enablement-stage::after {
+  background: var(--color-border-strong);
+}
+
+:root[data-theme='dark'] .stage-index {
+  background: rgba(96, 165, 250, 0.22);
+}
+
+.enablement-stage > div:last-child .card-desc {
+  margin-top: 0;
 }
 
 .eyebrow {


### PR DESCRIPTION
## Summary
- remove the gradient backdrop from the hero illustration so the SVG sits on a clean surface
- ensure the outcomes footnote regains vertical spacing even with the section-specific muted rule
- redesign the enablement timeline into a compact stepped layout with highlighted stages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e38db23574832587bf959321d1fedf