### PR TITLE
Adjust mobile header controls layout

### DIFF
--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -171,9 +171,21 @@ section > .muted {
   flex-wrap: wrap;
 }
 
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  order: 2;
+}
+
 @media (min-width: 860px) {
   .header-inner {
     flex-wrap: nowrap;
+  }
+
+  .header-controls {
+    order: 3;
+    margin-left: clamp(18px, 4vw, 32px);
   }
 }
 
@@ -223,8 +235,12 @@ section > .muted {
 }
 
 @media (max-width: 859px) {
-  .nav-toggle {
+  .header-controls {
     margin-left: auto;
+  }
+
+  .nav-toggle {
+    margin-left: 0;
   }
 }
 
@@ -336,6 +352,7 @@ html.no-js .nav-toggle {
     gap: 18px;
     margin-left: clamp(18px, 4vw, 36px);
     min-width: 0;
+    order: 2;
   }
 
   .nav-toggle {
@@ -418,21 +435,7 @@ html.no-js .nav-toggle {
 
 @media (max-width: 859px) {
   .actions {
-    order: 2;
-    width: 100%;
-    margin-left: 0;
-    justify-content: space-between;
-    align-items: center;
-    gap: 14px;
-  }
-
-  .icon-switchers {
-    order: 2;
-  }
-
-  .actions [data-scroll-to-pilots] {
-    flex: 1 1 auto;
-    width: auto;
+    display: none;
   }
 }
 

--- a/views/partials/header.php
+++ b/views/partials/header.php
@@ -41,21 +41,15 @@ $logoPath = asset('assets/img/logo-nerp.svg');
                 <?php endif; ?>
             </span>
         </a>
-        <button class="nav-toggle" type="button" data-nav-toggle aria-controls="mainNav" aria-expanded="false">
-            <span class="nav-toggle-box" aria-hidden="true">
-                <span class="nav-toggle-bar"></span>
-                <span class="nav-toggle-bar"></span>
-                <span class="nav-toggle-bar"></span>
-            </span>
-            <span class="sr-only"><?= e($t->get('nav.toggle')); ?></span>
-        </button>
-        <nav class="nav" id="mainNav" aria-label="Main navigation" role="navigation" data-nav>
-            <a href="<?= e($homeUrl); ?>#for"><?= e($t->get('nav.for')); ?></a>
-            <a href="<?= e($homeUrl); ?>#why"><?= e($t->get('nav.why')); ?></a>
-            <a href="<?= e($homeUrl); ?>#pricing"><?= e($t->get('nav.pricing')); ?></a>
-            <a href="<?= e($homeUrl); ?>#pilots"><?= e($t->get('nav.pilots')); ?></a>
-        </nav>
-        <div class="actions">
+        <div class="header-controls">
+            <button class="nav-toggle" type="button" data-nav-toggle aria-controls="mainNav" aria-expanded="false">
+                <span class="nav-toggle-box" aria-hidden="true">
+                    <span class="nav-toggle-bar"></span>
+                    <span class="nav-toggle-bar"></span>
+                    <span class="nav-toggle-bar"></span>
+                </span>
+                <span class="sr-only"><?= e($t->get('nav.toggle')); ?></span>
+            </button>
             <div class="icon-switchers">
                 <button
                     class="icon-toggle"
@@ -84,6 +78,14 @@ $logoPath = asset('assets/img/logo-nerp.svg');
                     <span class="sr-only"><?= e($t->get('app.theme.toggle')); ?></span>
                 </button>
             </div>
+        </div>
+        <nav class="nav" id="mainNav" aria-label="Main navigation" role="navigation" data-nav>
+            <a href="<?= e($homeUrl); ?>#for"><?= e($t->get('nav.for')); ?></a>
+            <a href="<?= e($homeUrl); ?>#why"><?= e($t->get('nav.why')); ?></a>
+            <a href="<?= e($homeUrl); ?>#pricing"><?= e($t->get('nav.pricing')); ?></a>
+            <a href="<?= e($homeUrl); ?>#pilots"><?= e($t->get('nav.pilots')); ?></a>
+        </nav>
+        <div class="actions">
             <a
                 class="btn btn-primary"
                 href="<?= e($homeUrl); ?>#pilots"


### PR DESCRIPTION
## Summary
- move the language and theme toggles into a shared header-controls block beside the logo
- update header styles so the toggles sit with the brand on mobile while the navigation keeps desktop spacing
- hide the pilot CTA button on mobile widths to declutter the compact header

## Testing
- php -l views/partials/header.php

------
https://chatgpt.com/codex/tasks/task_e_68e3a2bbb5c483259336d9140851aaa4